### PR TITLE
Fix errors after updating NativeScript

### DIFF
--- a/powerinfo.android.ts
+++ b/powerinfo.android.ts
@@ -1,6 +1,7 @@
-import app = require("application");
+import * as app from "tns-core-modules/application";
+
 declare let android: any;
-interface PowerData {
+export interface PowerData {
     health: number;
     icon_small: number;
     present: boolean;


### PR DESCRIPTION
TS1202: Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.

Cannot find module 'application'.

'"powerinfo"' has no exported member 'PowerData'.